### PR TITLE
Fix "cannot get out of airplane mode" issue

### DIFF
--- a/ril/com/android/internal/telephony/MediaTekRIL.java
+++ b/ril/com/android/internal/telephony/MediaTekRIL.java
@@ -924,7 +924,7 @@ public class MediaTekRIL extends RIL implements CommandsInterface {
         if (RILJ_LOGD) riljLog(rr.serialString() + "> " + requestToString(rr.mRequest));
 
         rr.mParcel.writeInt(1);
-        rr.mParcel.writeInt(on ? 3 : -1); // SIM1 | SIM2 ?
+        rr.mParcel.writeInt(on ? 3 : 0); // SIM1 | SIM2 ?
         send(rr);
     }
 


### PR DESCRIPTION
The radio remains in OFF state after even after switching off the airplane mode and phone requires restart to be operational. This fixes "cannot get out of airplane mode" issue without restart.
